### PR TITLE
Search component: remove padding from default slot container

### DIFF
--- a/src/lib/forms/Search.svelte
+++ b/src/lib/forms/Search.svelte
@@ -54,7 +54,7 @@
     Due to that we need the below slot and Wrapper around
   -->
   {#if $$slots.default}
-    <div class="flex absolute inset-y-0 right-0 items-center pr-3 text-gray-500 dark:text-gray-400">
+    <div class="flex absolute inset-y-0 right-0 items-center text-gray-500 dark:text-gray-400">
       <slot />
     </div>
   {/if}


### PR DESCRIPTION
## 📑 Description

Removes padding from the slot container on the search input as it breaks button positioning.

## Status

- [x] Not Completed
- [] Completed

## ✅ Checks

- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] I have checked the page with https://validator.unl.edu/
- [x] All the tests have passed
- [x] My pull request is based on the latest commit (not the npm version).
